### PR TITLE
fixed issue with Linux workstations that aren't use php@

### DIFF
--- a/src/utils/GetValetList.ts
+++ b/src/utils/GetValetList.ts
@@ -29,9 +29,13 @@ export default function getValetList() {
                 key: element.key.replace("//", ""),
                 value: element.value
             };
-        });
+        });      
+        
+        let versions = [...output.toString().matchAll(/php@([0-9.0-9]+)/gm)];
 
-        let versions = [...output.toString().matchAll(/php@([0-9.0-9]+)/gm)]
+        if(versions.length === 0) {
+            versions = [...output.toString().matchAll(/([0-9]+\.[0-9]+)/gm)];
+        }
 
         projectslist = JSON.stringify(output.toString()).match(/https?:[^\s|]+/gm)?.map((link, index) => {
             let name = [...link.matchAll(/^https?:\/\/([^.]+)\./gm)]


### PR DESCRIPTION
Linux valet is not using e.g: php@8.2 but use it like this: 8.2

here I checked the platform that the VS code is running on and changed the versions to be suitable with Linux workstations also not affect MacOS users